### PR TITLE
Fix RangeError in messageDeleteBulk logging

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -102,10 +102,12 @@ client.on('messageDeleteBulk', (messages) => {
 		if (rows[0] && rows[0]['messageDelete']) {
 			let fields = [];
 			messages.each(message => {
+				let content = message.content
+				if (!content) content = `Message data unavailable, message likely included an attachment or embed.`;
 				fields.push({
 					name: `${message.author.tag} | id: ${message.author.id}`,
 					inline: false,
-					value: message.content
+					value: content
 				});
 			})
 			client.channels.cache.get(rows[0]['messageLogChannel']).send({


### PR DESCRIPTION
If a message contained an attachment, embed, or anything of that nature, the bot failed to post the messageDeleteBulk log due to a RangeError. This was because the bot is not permitted to send empty content in an embed (by Discord), and attachments/embeds don't get pushed to fields, so empty content was the result. Anyway, this is the fix I wrote for it, if there's something cleaner instead, let me know. Thanks wagon